### PR TITLE
Updated Spotter's Ability

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -427,7 +427,7 @@
 		overlays += cas_laser_overlay
 
 /datum/action/item_action/specialist/spotter_target
-	ability_primacy = SPEC_PRIMARY_ACTION_1
+	ability_primacy = SPEC_PRIMARY_ACTION_2
 	var/minimum_laze_distance = 2
 
 /datum/action/item_action/specialist/spotter_target/New(mob/living/user, obj/item/holder)


### PR DESCRIPTION
Changes the ability to spot mobs as a spotter to spec_activation_2, allowing for spotters to separately cloak with the armor and activate spotting.



# About the pull request

This changes the spotter's ability to use your ability activation button to spot targets to the other available ability, no longer forcing spotter to double up on having the cloak and the laser designator share the same button.

# Explain why it's good for the game

As it stands right now, a spotter with the full gear cannot make effective and quick use of their ghillie suit and laser designator. If you have a keybind for specialist abilities, both the cloak and the activation of spotting are bound to the same key. This swaps the spotting key to spec ability 2, giving Spotter's two distinct abilities that can be managed easily via keybind.


# Testing Photographs and Procedure
N/A

# Changelog



:cl:
qol: Changed Spotter's spotting to ability 2 to prevent doubling up with ghillie suit cloaking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
